### PR TITLE
Add getPyUnicodeUtf8 function

### DIFF
--- a/include/pybind11/detail/non_limited_api.h
+++ b/include/pybind11/detail/non_limited_api.h
@@ -190,6 +190,8 @@ PYBIND11_NONLIMITEDAPI_FUNC(int, pybind11_clear, (PyObject *self), (self))
 PYBIND11_NONLIMITEDAPI_FUNC(void, globals, (std::optional<dict> &out), (out))
 PYBIND11_NONLIMITEDAPI_FUNC(PyObject *, dict_getitemstringref, (PyObject *v, const char *key), (v, key))
 
+PYBIND11_NONLIMITEDAPI_FUNC(bool, getPyUnicodeUtf8, (PyObject * obj, const char *& data, size_t & length, int & kind, size_t & codepoint_cnt, bool & direct_insert), (obj, data, length, kind, codepoint_cnt, direct_insert))
+
 PYBIND11_NAMESPACE_END(non_limited_api)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)
 

--- a/source/non_limited_api/non_limited_api.cpp
+++ b/source/non_limited_api/non_limited_api.cpp
@@ -1907,3 +1907,68 @@ PyObject *pybind11::non_limited_api::pybind11NLA_dict_getitemstringref(PyObject 
     return rv;
 #endif
 }
+
+bool pybind11::non_limited_api::pybind11NLA_getPyUnicodeUtf8(PyObject * obj, const char *& data, size_t & length, int & kind, size_t & codepoint_cnt, bool & direct_insert)
+{
+    direct_insert = true;
+
+    if (PyUnicode_IS_COMPACT_ASCII(obj))
+    {
+        /// if obj is unicode
+        data = reinterpret_cast<const char *>(PyUnicode_1BYTE_DATA(obj));
+        length = PyUnicode_GET_LENGTH(obj);
+        return true;
+    }
+
+    auto * unicode = reinterpret_cast<PyCompactUnicodeObject *>(obj);
+    if (unicode->utf8 != nullptr)
+    {
+        /// It's utf8 string, treat it like ASCII
+        data = reinterpret_cast<const char *>(unicode->utf8);
+        length = unicode->utf8_length;
+        return true;
+    }
+
+    if (PyUnicode_IS_COMPACT(obj))
+    {
+        kind = PyUnicode_KIND(obj);
+        if (kind == PyUnicode_1BYTE_KIND)
+        {
+            data = reinterpret_cast<const char *>(PyUnicode_1BYTE_DATA(obj));
+        }
+        else if (kind == PyUnicode_2BYTE_KIND)
+        {
+            data = reinterpret_cast<const char *>(PyUnicode_2BYTE_DATA(obj));
+        }
+        else if (kind == PyUnicode_4BYTE_KIND)
+        {
+            data = reinterpret_cast<const char *>(PyUnicode_4BYTE_DATA(obj));
+        }
+        else
+        {
+            return false;
+        }
+
+        // always convert it to utf8, and we can't use as function provided by CPython because it requires GIL
+        // holded by the caller. So we have to do it manually with libicu
+        codepoint_cnt = PyUnicode_GET_LENGTH(obj);
+
+        direct_insert = false;
+        return true;
+    }
+
+    // always convert it to utf8, but this case is rare, here goes the slow path
+    pybind11::gil_scoped_acquire acquire;
+    // PyUnicode_AsUTF8AndSize caches the UTF-8 encoded string in the unicodeobject
+    // and subsequent calls will return the same string.  The memory is released
+    // when the unicodeobject is deallocated.
+    Py_ssize_t bytes_size = -1;
+    data = ::PyUnicode_AsUTF8AndSize(obj, &bytes_size);
+    if (!data || bytes_size < 0)
+    {
+        return false;
+    }
+
+    length = bytes_size;
+    return true;
+}


### PR DESCRIPTION
Dear maintainers,

First, I'd like to express my gratitude for the excellent work on mrbind-pybind11. This project has been instrumental in helping us build the Python wheel for [chdb](https://github.com/chdb-io/chdb), enabling support for multiple Python versions through the stable C API.

In our work with chdb, we needed a way to retrieve the UTF-8 string content of Python objects while operating in stable API mode. To address this, I've added a new function that handles this scenario, ensuring compatibility with the stable C API constraints across Python 3.8 to 3.13. I'm submitting this PR in case it benefits the community. It’s our small way of contributing back to a tool that has supported our project so effectively.

Thank you again for your work on this repository!